### PR TITLE
Remove `sp_std` dependency

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -30,7 +30,6 @@ arbitrary_precision = ["serde_json/arbitrary_precision"]
 default = ["std"]
 std = [
 	"log/std",
-	"sp-std/std",
 	"serde/std",
 	"serde_json/std",
 	"futures/std",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,18 +21,20 @@ categories = [
 [dependencies]
 log = { git = "https://github.com/mesalock-linux/log-sgx", default-features = false }
 futures = { git = "https://github.com/mesalock-linux/futures-rs-sgx" }
-serde = { git = "https://github.com/mesalock-linux/serde-sgx", features = [
-	"derive",
-] }
-serde_json = { git = "https://github.com/mesalock-linux/serde-json-sgx", features = [
-	"alloc",
-] }
-serde_derive = { git = "https://github.com/mesalock-linux/serde-sgx" }
+serde        	  = { git = "https://github.com/mesalock-linux/serde-sgx", features = ["derive"]  }
+serde_json        = { git = "https://github.com/mesalock-linux/serde-json-sgx", features = ["alloc"]}
+serde_derive      = { git = "https://github.com/mesalock-linux/serde-sgx" }
 
 [features]
 arbitrary_precision = ["serde_json/arbitrary_precision"]
 default = ["std"]
-std = ["log/std", "sp-std/std", "serde/std", "serde_json/std", "futures/std"]
+std = [
+	"log/std",
+	"sp-std/std",
+	"serde/std",
+	"serde_json/std",
+	"futures/std",
+]
 
 [badges]
-travis-ci = { repository = "paritytech/jsonrpc", branch = "master" }
+travis-ci = { repository = "paritytech/jsonrpc", branch = "master"}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,26 +21,18 @@ categories = [
 [dependencies]
 log = { git = "https://github.com/mesalock-linux/log-sgx", default-features = false }
 futures = { git = "https://github.com/mesalock-linux/futures-rs-sgx" }
-serde        	  = { git = "https://github.com/mesalock-linux/serde-sgx", features = ["derive"]  }
-serde_json        = { git = "https://github.com/mesalock-linux/serde-json-sgx", features = ["alloc"]}
-serde_derive      = { git = "https://github.com/mesalock-linux/serde-sgx" }
-
-[dependencies.sp-std]
-git = "https://github.com/paritytech/substrate.git"
-branch = "master"
-version = "4.0.0-dev"
-default-features = false
+serde = { git = "https://github.com/mesalock-linux/serde-sgx", features = [
+	"derive",
+] }
+serde_json = { git = "https://github.com/mesalock-linux/serde-json-sgx", features = [
+	"alloc",
+] }
+serde_derive = { git = "https://github.com/mesalock-linux/serde-sgx" }
 
 [features]
 arbitrary_precision = ["serde_json/arbitrary_precision"]
 default = ["std"]
-std = [
-	"log/std",
-	"sp-std/std",
-	"serde/std",
-	"serde_json/std",
-	"futures/std",
-]
+std = ["log/std", "sp-std/std", "serde/std", "serde_json/std", "futures/std"]
 
 [badges]
-travis-ci = { repository = "paritytech/jsonrpc", branch = "master"}
+travis-ci = { repository = "paritytech/jsonrpc", branch = "master" }

--- a/core/examples/params.rs
+++ b/core/examples/params.rs
@@ -1,9 +1,7 @@
+#[cfg(not(feature = "std"))]
+use alloc::{borrow::ToOwned, string::String};
 use jsonrpc_core::*;
 use serde::Deserialize;
-use sp_std::borrow::ToOwned;
-#[cfg(not(feature = "std"))]
-use alloc::string::String;
-
 
 #[derive(Deserialize)]
 struct HelloParams {

--- a/core/src/calls.rs
+++ b/core/src/calls.rs
@@ -1,13 +1,11 @@
 use crate::types::{Error, Params, Value};
 use crate::BoxFuture;
 use futures::Future;
-use sp_std::boxed::Box;
-use sp_std::fmt;
 
 #[cfg(not(feature = "std"))]
-use alloc::{string::String, sync::Arc};
+use alloc::{boxed::Box, fmt, string::String, sync::Arc};
 #[cfg(feature = "std")]
-use std::sync::Arc;
+use std::{boxed::Box, fmt, string::String, sync::Arc};
 
 /// Metadata trait
 pub trait Metadata: Clone + Send + 'static {}

--- a/core/src/delegates.rs
+++ b/core/src/delegates.rs
@@ -1,17 +1,11 @@
 //! Delegate rpc calls
-#[cfg(not(feature = "std"))]
-use alloc::collections::BTreeMap;
-#[cfg(feature = "std")]
-use std::collections::HashMap;
 
 use futures::Future;
 
 #[cfg(not(feature = "std"))]
-use alloc::{string::String, sync::Arc};
+use crate::alloc::{boxed::Box, collections::BTreeMap, string::String, sync::Arc};
 #[cfg(feature = "std")]
-use std::sync::Arc;
-
-use sp_std::boxed::Box;
+use std::{boxed::Box, collections::HashMap, string::String, sync::Arc, sync::Arc};
 
 use crate::calls::{Metadata, RemoteProcedure, RpcMethod, RpcNotification};
 

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -1,23 +1,25 @@
 #[cfg(not(feature = "std"))]
-use alloc::{
+use crate::alloc::{
+	boxed::Box,
 	collections::{
 		btree_map::{IntoIter, Iter},
 		BTreeMap,
 	},
+	ops::{Deref, DerefMut},
 	string::String,
 	string::ToString,
-};
-use core::pin::Pin;
-use futures::{self, future, Future, FutureExt};
-use sp_std::{
-	boxed::Box,
-	ops::{Deref, DerefMut},
 	sync::Arc,
 	vec::Vec,
 };
+use core::pin::Pin;
+use futures::{self, future, Future, FutureExt};
 #[cfg(feature = "std")]
 use std::collections::{
+	boxed::Box,
 	hash_map::{IntoIter, Iter},
+	ops::{Deref, DerefMut},
+	sync::Arc,
+	vec::Vec,
 	HashMap,
 };
 

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -653,10 +653,9 @@ mod tests {
 		use super::IoHandlerExtension;
 		use crate::delegates::IoDelegate;
 		#[cfg(not(feature = "std"))]
-		use alloc::sync::Arc;
-		use sp_std::boxed::Box;
+		use alloc::{boxed::Box, sync::Arc};
 		#[cfg(feature = "std")]
-		use std::sync::Arc;
+		use std::{boxed::Box, sync::Arc};
 
 		struct Test;
 		impl Test {

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -5,19 +5,20 @@ use crate::alloc::{
 		btree_map::{IntoIter, Iter},
 		BTreeMap,
 	},
-	ops::{Deref, DerefMut},
 	string::String,
 	string::ToString,
 	sync::Arc,
 	vec::Vec,
 };
-use core::pin::Pin;
+use core::{
+	ops::{Deref, DerefMut},
+	pin::Pin,
+};
 use futures::{self, future, Future, FutureExt};
 #[cfg(feature = "std")]
 use std::collections::{
 	boxed::Box,
 	hash_map::{IntoIter, Iter},
-	ops::{Deref, DerefMut},
 	sync::Arc,
 	vec::Vec,
 	HashMap,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -24,14 +24,10 @@
 #[cfg(not(feature = "std"))]
 pub extern crate alloc;
 
-pub extern crate sp_std;
-use sp_std::boxed::Box;
-use sp_std::str;
-
 #[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, str};
+
 use core::pin::Pin;
-#[cfg(feature = "std")]
-use std::pin::Pin;
 
 #[macro_use]
 extern crate log;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -47,7 +47,7 @@ pub mod middleware;
 pub mod types;
 
 /// A Result type.
-pub type Result<T> = sp_std::result::Result<T, Error>;
+pub type Result<T> = core::result::Result<T, Error>;
 
 /// A `Future` trait object.
 pub type BoxFuture<T> = Pin<Box<dyn futures::Future<Output = T> + Send>>;
@@ -69,7 +69,7 @@ use serde_json::Error as SerdeError;
 /// workaround for https://github.com/serde-rs/json/issues/505
 /// Arbitrary precision confuses serde when deserializing into untagged enums,
 /// this is a workaround
-pub fn serde_from_str<'a, T>(input: &'a str) -> sp_std::result::Result<T, SerdeError>
+pub fn serde_from_str<'a, T>(input: &'a str) -> core::result::Result<T, SerdeError>
 where
 	T: serde::de::Deserialize<'a>,
 {

--- a/core/src/middleware.rs
+++ b/core/src/middleware.rs
@@ -1,13 +1,14 @@
 //! `IoHandler` middlewares
 
+#[cfg(not(feature = "std"))]
+use crate::alloc::boxed::Box;
+#[cfg(feature = "std")]
+use std::boxed::Box;
+
 use crate::calls::Metadata;
 use crate::types::{Call, Output, Request, Response};
-#[cfg(not(feature = "std"))]
 use core::pin::Pin;
 use futures::{future::Either, Future};
-use sp_std::boxed::Box;
-#[cfg(feature = "std")]
-use std::pin::Pin;
 
 /// RPC middleware
 pub trait Middleware<M: Metadata>: Send + Sync + 'static {

--- a/core/src/types/error.rs
+++ b/core/src/types/error.rs
@@ -1,16 +1,13 @@
 //! jsonrpc errors
 #[cfg(not(feature = "std"))]
-use alloc::{string::{ToString, String}, format};
-
-pub extern crate sp_std;
-use sp_std::borrow::ToOwned;
-
+use alloc::{
+	borrow::ToOwned,
+	fmt, format,
+	string::{String, ToString},
+};
 
 use super::Value;
-use serde::{Serialize, Serializer, Deserialize, Deserializer};
-//use serde::de::{Deserializer};
-//use serde::ser::{Serializer};
-use sp_std::fmt;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// JSONRPC error code
 #[derive(Debug, PartialEq, Clone)]

--- a/core/src/types/error.rs
+++ b/core/src/types/error.rs
@@ -164,8 +164,8 @@ impl Error {
 	}
 }
 
-impl sp_std::fmt::Display for Error {
-	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
+impl crate::alloc::fmt::Display for Error {
+	fn fmt(&self, f: &mut alloc::fmt::Formatter) -> crate::alloc::fmt::Result {
 		write!(f, "{}: {}", self.code.description(), self.message)
 	}
 }

--- a/core/src/types/id.rs
+++ b/core/src/types/id.rs
@@ -1,7 +1,7 @@
 //! jsonrpc id field
-use serde::{Serialize, Deserialize};
 #[cfg(not(feature = "std"))]
 use alloc::string::String;
+use serde::{Deserialize, Serialize};
 
 /// Request Id
 #[derive(Debug, PartialEq, Clone, Hash, Eq, Deserialize, Serialize)]
@@ -19,13 +19,14 @@ pub enum Id {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::alloc;
 	use serde_json;
 
 	#[test]
 	fn id_deserialization() {
-		use sp_std::vec;
-		use sp_std::vec::Vec;
-		use sp_std::borrow::ToOwned;
+		use alloc::borrow::ToOwned;
+		use alloc::vec;
+		use alloc::vec::Vec;
 
 		let s = r#""2""#;
 		let deserialized: Id = serde_json::from_str(s).unwrap();
@@ -49,8 +50,8 @@ mod tests {
 
 	#[test]
 	fn id_serialization() {
-		use sp_std::vec;
-		use sp_std::borrow::ToOwned;
+		use alloc::borrow::ToOwned;
+		use alloc::vec;
 		let d = vec![
 			Id::Null,
 			Id::Num(0),

--- a/core/src/types/params.rs
+++ b/core/src/types/params.rs
@@ -1,15 +1,10 @@
 //! jsonrpc params field
-use serde::{Serialize, Deserialize};
 use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
 use serde_json::value::from_value;
 
-use sp_std::vec::Vec;
-
 #[cfg(not(feature = "std"))]
-use alloc::string::String;
-#[cfg(not(feature = "std"))]
-use alloc::format;
-
+use alloc::{format, string::String, vec::Vec};
 
 use super::{Error, Value};
 
@@ -63,9 +58,9 @@ mod tests {
 	use serde_json;
 
 	#[cfg(not(feature = "std"))]
-	use alloc::vec;
-	#[cfg(not(feature = "std"))]
 	use alloc::string::ToString;
+	#[cfg(not(feature = "std"))]
+	use alloc::vec;
 
 	#[test]
 	fn params_deserialization() {

--- a/core/src/types/request.rs
+++ b/core/src/types/request.rs
@@ -1,14 +1,10 @@
 //! jsonrpc request
 
 use super::{Id, Params, Version};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[cfg(not(feature = "std"))]
-use sp_std::vec::Vec;
-
-#[cfg(not(feature = "std"))]
-use alloc::string::String;
-
+use alloc::{string::String, vec::Vec};
 
 /// Represents jsonrpc request which is a method call.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
@@ -98,8 +94,8 @@ mod tests {
 	fn method_call_serialize() {
 		use serde_json;
 		use serde_json::Value;
-		use sp_std::vec;
 		use sp_std::borrow::ToOwned;
+		use sp_std::vec;
 
 		let m = MethodCall {
 			jsonrpc: Some(Version::V2),
@@ -119,8 +115,8 @@ mod tests {
 	fn notification_serialize() {
 		use serde_json;
 		use serde_json::Value;
-		use sp_std::vec;
 		use sp_std::borrow::ToOwned;
+		use sp_std::vec;
 
 		let n = Notification {
 			jsonrpc: Some(Version::V2),
@@ -136,8 +132,8 @@ mod tests {
 	fn call_serialize() {
 		use serde_json;
 		use serde_json::Value;
-		use sp_std::vec;
 		use sp_std::borrow::ToOwned;
+		use sp_std::vec;
 
 		let n = Call::Notification(Notification {
 			jsonrpc: Some(Version::V2),
@@ -152,8 +148,8 @@ mod tests {
 	#[test]
 	fn request_serialize_batch() {
 		use serde_json;
-		use sp_std::vec;
 		use sp_std::borrow::ToOwned;
+		use sp_std::vec;
 
 		let batch = Request::Batch(vec![
 			Call::MethodCall(MethodCall {
@@ -180,8 +176,8 @@ mod tests {
 	fn notification_deserialize() {
 		use serde_json;
 		use serde_json::Value;
-		use sp_std::vec;
 		use sp_std::borrow::ToOwned;
+		use sp_std::vec;
 
 		let s = r#"{"jsonrpc": "2.0", "method": "update", "params": [1,2]}"#;
 		let deserialized: Notification = serde_json::from_str(s).unwrap();
@@ -215,8 +211,8 @@ mod tests {
 	#[test]
 	fn call_deserialize() {
 		use serde_json;
-		use sp_std::vec;
 		use sp_std::borrow::ToOwned;
+		use sp_std::vec;
 
 		let s = r#"{"jsonrpc": "2.0", "method": "update", "params": [1]}"#;
 		let deserialized: Call = serde_json::from_str(s).unwrap();
@@ -281,8 +277,8 @@ mod tests {
 	#[test]
 	fn request_deserialize_batch() {
 		use serde_json;
-		use sp_std::vec;
 		use sp_std::borrow::ToOwned;
+		use sp_std::vec;
 
 		let s = r#"[{}, {"jsonrpc": "2.0", "method": "update", "params": [1,2], "id": 1},{"jsonrpc": "2.0", "method": "update", "params": [1]}]"#;
 		let deserialized: Request = serde_json::from_str(s).unwrap();

--- a/core/src/types/request.rs
+++ b/core/src/types/request.rs
@@ -88,14 +88,15 @@ pub enum Request {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::alloc;
 	use serde_json::Value;
 
 	#[test]
 	fn method_call_serialize() {
+		use alloc::borrow::ToOwned;
+		use alloc::vec;
 		use serde_json;
 		use serde_json::Value;
-		use sp_std::borrow::ToOwned;
-		use sp_std::vec;
 
 		let m = MethodCall {
 			jsonrpc: Some(Version::V2),
@@ -113,10 +114,10 @@ mod tests {
 
 	#[test]
 	fn notification_serialize() {
+		use alloc::borrow::ToOwned;
+		use alloc::vec;
 		use serde_json;
 		use serde_json::Value;
-		use sp_std::borrow::ToOwned;
-		use sp_std::vec;
 
 		let n = Notification {
 			jsonrpc: Some(Version::V2),
@@ -130,10 +131,10 @@ mod tests {
 
 	#[test]
 	fn call_serialize() {
+		use alloc::borrow::ToOwned;
+		use alloc::vec;
 		use serde_json;
 		use serde_json::Value;
-		use sp_std::borrow::ToOwned;
-		use sp_std::vec;
 
 		let n = Call::Notification(Notification {
 			jsonrpc: Some(Version::V2),
@@ -147,9 +148,9 @@ mod tests {
 
 	#[test]
 	fn request_serialize_batch() {
+		use alloc::borrow::ToOwned;
+		use alloc::vec;
 		use serde_json;
-		use sp_std::borrow::ToOwned;
-		use sp_std::vec;
 
 		let batch = Request::Batch(vec![
 			Call::MethodCall(MethodCall {
@@ -174,10 +175,10 @@ mod tests {
 
 	#[test]
 	fn notification_deserialize() {
+		use alloc::borrow::ToOwned;
+		use alloc::vec;
 		use serde_json;
 		use serde_json::Value;
-		use sp_std::borrow::ToOwned;
-		use sp_std::vec;
 
 		let s = r#"{"jsonrpc": "2.0", "method": "update", "params": [1,2]}"#;
 		let deserialized: Notification = serde_json::from_str(s).unwrap();
@@ -210,9 +211,9 @@ mod tests {
 
 	#[test]
 	fn call_deserialize() {
+		use alloc::borrow::ToOwned;
+		use alloc::vec;
 		use serde_json;
-		use sp_std::borrow::ToOwned;
-		use sp_std::vec;
 
 		let s = r#"{"jsonrpc": "2.0", "method": "update", "params": [1]}"#;
 		let deserialized: Call = serde_json::from_str(s).unwrap();
@@ -276,9 +277,9 @@ mod tests {
 
 	#[test]
 	fn request_deserialize_batch() {
+		use alloc::borrow::ToOwned;
+		use alloc::vec;
 		use serde_json;
-		use sp_std::borrow::ToOwned;
-		use sp_std::vec;
 
 		let s = r#"[{}, {"jsonrpc": "2.0", "method": "update", "params": [1,2], "id": 1},{"jsonrpc": "2.0", "method": "update", "params": [1]}]"#;
 		let deserialized: Request = serde_json::from_str(s).unwrap();

--- a/core/src/types/response.rs
+++ b/core/src/types/response.rs
@@ -238,9 +238,9 @@ fn single_response_deserialize() {
 
 #[test]
 fn batch_response_deserialize() {
+	use alloc::vec;
 	use serde_json;
 	use serde_json::Value;
-	use sp_std::vec;
 
 	let dbr = r#"[{"jsonrpc":"2.0","result":1,"id":1},{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error"},"id":1}]"#;
 
@@ -287,8 +287,8 @@ fn handle_incorrect_responses() {
 
 #[test]
 fn should_parse_empty_response_as_batch() {
+	use alloc::vec;
 	use serde_json;
-	use sp_std::vec;
 
 	let dsr = r#""#;
 

--- a/core/src/types/response.rs
+++ b/core/src/types/response.rs
@@ -1,9 +1,10 @@
 //! jsonrpc response
 use super::{Error, ErrorCode, Id, Value, Version};
 use crate::Result as CoreResult;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
-use sp_std::{vec::Vec, vec};
+#[cfg(not(feature = "std"))]
+use crate::alloc::{vec, vec::Vec};
 
 /// Successful response
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]

--- a/core/src/types/version.rs
+++ b/core/src/types/version.rs
@@ -2,7 +2,11 @@
 use serde::de::{self, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use sp_std::fmt;
+#[cfg(not(feature = "std"))]
+use crate::alloc::fmt;
+
+#[cfg(feature = "std")]
+use std::fmt;
 
 /// Protocol Version
 #[derive(Debug, PartialEq, Clone, Copy, Hash, Eq)]


### PR DESCRIPTION
Once substrate updates their versions, this caused problems for this crate. So I removed it completely and replaced it with `alloc` and `core`. Should be less maintenance work in the future.

Tested compilation with the worker. All good :)